### PR TITLE
Fix CSS build path and PostCSS plugin

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "tailwind.config.js",
   "scripts": {
-    "build-css": "npx postcss ./assets/css/main.css -o ./static/css/main.css"
+    "build-css": "npx postcss ./assets/css/consolidated.css -o ./static/css/consolidated.css"
   },
   "keywords": [],
   "author": "",

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   }
 } 


### PR DESCRIPTION
## Summary
- update build-css script to use consolidated.css
- correct Tailwind plugin name in postcss config

## Testing
- `npm run build-css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/postcss)*

------
https://chatgpt.com/codex/tasks/task_e_6878e961b3e4832fbef5b4cad001574f